### PR TITLE
Add back `@ConditionalOnMissingBean(AsyncConfigurer.class)`

### DIFF
--- a/src/main/java/devbury/threadscope/SchedulerConfiguration.java
+++ b/src/main/java/devbury/threadscope/SchedulerConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.concurrent.Executor;
 
+@ConditionalOnMissingBean(AsyncConfigurer.class)
 @EnableAsync
 public class SchedulerConfiguration implements AsyncConfigurer {
 


### PR DESCRIPTION
Removing `@ConditionalOnMissingBean(AsyncConfigurer.class)` disallows user-defined configuration for `AsyncConfigurer`.